### PR TITLE
⚡ Optimize DataFrame iteration in win rate calculation

### DIFF
--- a/src/performance_monitor.py
+++ b/src/performance_monitor.py
@@ -745,11 +745,11 @@ class PerformanceMonitor:
             losses = 0
             last_buy_price = 0
 
-            for index, row in df.iterrows():
-                if row['type'] == 'BUY':
-                    last_buy_price = row['price']
-                elif row['type'] == 'SELL' and last_buy_price > 0:
-                    if row['price'] > last_buy_price:
+            for row in df.itertuples(index=False):
+                if row.type == 'BUY':
+                    last_buy_price = row.price
+                elif row.type == 'SELL' and last_buy_price > 0:
+                    if row.price > last_buy_price:
                         wins += 1
                     else:
                         losses += 1


### PR DESCRIPTION
💡 **What:** Replaced the inefficient `df.iterrows()` loop in `PerformanceMonitor._calculate_win_rate` with `df.itertuples(index=False)`.

🎯 **Why:** `iterrows()` is slow because it creates a pandas Series for each row. In contrast, `itertuples()` returns a namedtuple, which has significantly less overhead and is the recommended approach for row-wise iteration in pandas when vectorization is not possible.

📊 **Measured Improvement:** I was unable to provide a live benchmark result because the sandbox environment lacks the `pandas` dependency and has no internet access to install it. However, the use of `itertuples()` over `iterrows()` is a well-documented and standard performance optimization in the pandas ecosystem, typically resulting in a performance gain of one to two orders of magnitude for row-wise processing. The implementation was verified for syntax correctness and logic parity.

---
*PR created automatically by Jules for task [13293251892234373395](https://jules.google.com/task/13293251892234373395) started by @laurentvv*