### PR TITLE
🧹 [Code Health] Remove unused math import from advanced_risk_manager.py

### DIFF
--- a/src/advanced_risk_manager.py
+++ b/src/advanced_risk_manager.py
@@ -9,7 +9,6 @@ import pandas as pd
 from typing import Dict, List, Tuple, Optional
 from dataclasses import dataclass
 from enum import Enum
-import math
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `import math` statement from `src/advanced_risk_manager.py`.
💡 **Why:** Standard library unused imports clutter the file header, taking up unnecessary space without providing functionality. Cleaning this improves maintainability and adheres to code health practices.
✅ **Verification:** Verified `math` was not utilized anywhere in `src/advanced_risk_manager.py`. Successfully executed the python script without `math` imported and observed no compilation or logical changes.
✨ **Result:** Improved module cleanliness while preserving all existing functionality.

---
*PR created automatically by Jules for task [1625506361857599208](https://jules.google.com/task/1625506361857599208) started by @laurentvv*