### PR TITLE
🧹 Remove unused os import in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ Usage: python main.py --ticker QQQ
 
 import logging
 import sys
-import os
 import argparse
 from pathlib import Path
 from dotenv import load_dotenv


### PR DESCRIPTION
🎯 **What:** Removed the unused `import os` statement from `main.py:9`.
💡 **Why:** Reduces confusion and cleans up code by eliminating a module import that isn't actually referenced anywhere in the file. This makes the codebase cleaner and easier to maintain.
✅ **Verification:** Verified by running `ruff check main.py` before and after the change to confirm the unused import warning was resolved and checking the file parsed correctly.
✨ **Result:** Improved readability and removed a minor linter error in `main.py`.

---
*PR created automatically by Jules for task [3756600854453340212](https://jules.google.com/task/3756600854453340212) started by @laurentvv*