### PR TITLE
🧪 Add edge case tests for consensus score calculation

### DIFF
--- a/src/enhanced_decision_engine.py
+++ b/src/enhanced_decision_engine.py
@@ -135,7 +135,10 @@ class EnhancedDecisionEngine:
         signal_agreement = 1 - (signal_variance / max_variance)
         
         # Calculate confidence alignment (do high confidence models agree?)
-        weighted_signal = np.average(signals, weights=confidences)
+        if sum(confidences) == 0:
+            weighted_signal = np.mean(signals)
+        else:
+            weighted_signal = np.average(signals, weights=confidences)
         confidence_alignment = 1 - np.average([abs(s - weighted_signal) for s in signals])
         
         # Combined consensus score

--- a/tests/test_enhanced_decision_engine.py
+++ b/tests/test_enhanced_decision_engine.py
@@ -1,0 +1,78 @@
+import unittest
+from datetime import datetime
+from src.enhanced_decision_engine import EnhancedDecisionEngine, ModelDecision, SignalStrength
+
+class TestEnhancedDecisionEngine(unittest.TestCase):
+    def setUp(self):
+        self.engine = EnhancedDecisionEngine()
+
+    def create_decision(self, signal, confidence, strength_val):
+        # Maps integer strength_val to SignalStrength enum roughly
+        strength_map = {
+            2: SignalStrength.STRONG_BUY,
+            1: SignalStrength.BUY,
+            0: SignalStrength.HOLD,
+            -1: SignalStrength.SELL,
+            -2: SignalStrength.STRONG_SELL
+        }
+        return ModelDecision(
+            signal=signal,
+            confidence=confidence,
+            strength=strength_map[strength_val],
+            timestamp=datetime.now(),
+            model_name="test_model"
+        )
+
+    def test_calculate_consensus_score_empty(self):
+        """Test with empty list of decisions"""
+        self.assertEqual(self.engine._calculate_consensus_score([]), 1.0)
+
+    def test_calculate_consensus_score_single(self):
+        """Test with a single decision"""
+        decisions = [self.create_decision("BUY", 0.8, 1)]
+        self.assertEqual(self.engine._calculate_consensus_score(decisions), 1.0)
+
+    def test_calculate_consensus_score_zero_confidence(self):
+        """Test with multiple decisions that all have 0.0 confidence (ZeroDivisionError fix)"""
+        decisions = [
+            self.create_decision("BUY", 0.0, 1),
+            self.create_decision("HOLD", 0.0, 0),
+            self.create_decision("SELL", 0.0, -1)
+        ]
+        score = self.engine._calculate_consensus_score(decisions)
+        self.assertTrue(0 <= score <= 1)
+
+    def test_calculate_consensus_score_perfect_consensus(self):
+        """Test with multiple decisions that agree perfectly"""
+        decisions = [
+            self.create_decision("STRONG_BUY", 0.9, 2),
+            self.create_decision("STRONG_BUY", 0.9, 2),
+            self.create_decision("STRONG_BUY", 0.9, 2)
+        ]
+        score = self.engine._calculate_consensus_score(decisions)
+        self.assertEqual(score, 1.0)
+
+    def test_calculate_consensus_score_high_disagreement(self):
+        """Test with decisions that are polar opposites"""
+        decisions = [
+            self.create_decision("STRONG_BUY", 1.0, 2),
+            self.create_decision("STRONG_SELL", 1.0, -2)
+        ]
+        score = self.engine._calculate_consensus_score(decisions)
+        # Variance of [2, -2] is 4, max_variance is 4, signal_agreement = 0
+        # weighted_signal is 0. confidence_alignment = 1 - average(abs(2-0), abs(-2-0)) = 1 - 2 = -1
+        # score = (0 + -1)/2 = -0.5, clamped to 0
+        self.assertEqual(score, 0.0)
+
+    def test_calculate_consensus_score_partial_agreement(self):
+        """Test with a mix of decisions"""
+        decisions = [
+            self.create_decision("BUY", 0.8, 1),
+            self.create_decision("STRONG_BUY", 0.6, 2),
+            self.create_decision("HOLD", 0.4, 0)
+        ]
+        score = self.engine._calculate_consensus_score(decisions)
+        self.assertTrue(0 < score < 1.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `_calculate_consensus_score` method in `src/enhanced_decision_engine.py` lacked tests, which made it vulnerable to edge case errors. This PR introduces robust unit tests and fixes a potential `ZeroDivisionError` bug when the sum of confidence weights is zero.

📊 **Coverage:** What scenarios are now tested
- Empty list of decisions
- Single decision list
- Decisions with a sum of 0 confidence (ZeroDivisionError scenario)
- Perfect consensus (full agreement)
- High disagreement (polar opposites)
- Partial agreement (mixed signals)

✨ **Result:** The improvement in test coverage
The mathematical logic calculating the model consensus is now fully covered, ensuring changes in this critical part of the decision engine are safe.

---
*PR created automatically by Jules for task [11888252942640544981](https://jules.google.com/task/11888252942640544981) started by @laurentvv*