### PR TITLE
🧪 Add tests for sentiment analysis logic

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,15 @@
+🧪 Add tests for sentiment analysis logic
+
+🎯 **What:**
+Added unit tests for `get_sentiment_decision_from_score` in `src/sentiment_analysis.py` to fill a missing testing gap.
+
+📊 **Coverage:**
+- BUY signals for scores > 0.15
+- SELL signals for scores < -0.15
+- HOLD signals for scores between -0.15 and 0.15
+- Exact boundary checks (0.15 and -0.15 resolve to HOLD)
+- Confidence capping behavior (confidence does not exceed 1.0)
+- Analysis string formatting
+
+✨ **Result:**
+Enhanced the test suite with robust coverage of sentiment analysis decisions, creating a safety net for future refactoring and capturing exact expected threshold logic.

--- a/tests/test_sentiment_analysis.py
+++ b/tests/test_sentiment_analysis.py
@@ -1,0 +1,56 @@
+import unittest
+from src.sentiment_analysis import get_sentiment_decision_from_score
+
+
+class TestSentimentAnalysis(unittest.TestCase):
+    def test_buy_signal(self):
+        """Test that scores > 0.15 result in BUY signal with correct confidence."""
+        result = get_sentiment_decision_from_score(0.20)
+        self.assertEqual(result["signal"], "BUY")
+        self.assertAlmostEqual(result["confidence"], 0.70)
+        self.assertEqual(result["analysis"], "Sentiment score from news API is 0.20.")
+
+        # Test extreme high score (confidence capping)
+        result_extreme = get_sentiment_decision_from_score(1.5)
+        self.assertEqual(result_extreme["signal"], "BUY")
+        self.assertEqual(result_extreme["confidence"], 1.0)
+
+    def test_sell_signal(self):
+        """Test that scores < -0.15 result in SELL signal with correct confidence."""
+        result = get_sentiment_decision_from_score(-0.20)
+        self.assertEqual(result["signal"], "SELL")
+        self.assertAlmostEqual(result["confidence"], 0.70)
+        self.assertEqual(result["analysis"], "Sentiment score from news API is -0.20.")
+
+        # Test extreme low score (confidence capping)
+        result_extreme = get_sentiment_decision_from_score(-1.5)
+        self.assertEqual(result_extreme["signal"], "SELL")
+        self.assertEqual(result_extreme["confidence"], 1.0)
+
+    def test_hold_signal(self):
+        """Test that scores between -0.15 and 0.15 result in HOLD signal."""
+        result = get_sentiment_decision_from_score(0.0)
+        self.assertEqual(result["signal"], "HOLD")
+        self.assertAlmostEqual(result["confidence"], 0.50)
+
+        result_pos = get_sentiment_decision_from_score(0.10)
+        self.assertEqual(result_pos["signal"], "HOLD")
+        self.assertAlmostEqual(result_pos["confidence"], 0.60)
+
+        result_neg = get_sentiment_decision_from_score(-0.10)
+        self.assertEqual(result_neg["signal"], "HOLD")
+        self.assertAlmostEqual(result_neg["confidence"], 0.60)
+
+    def test_boundary_values(self):
+        """Test exact boundary values (0.15 and -0.15)."""
+        result_upper = get_sentiment_decision_from_score(0.15)
+        self.assertEqual(result_upper["signal"], "HOLD")
+        self.assertAlmostEqual(result_upper["confidence"], 0.65)
+
+        result_lower = get_sentiment_decision_from_score(-0.15)
+        self.assertEqual(result_lower["signal"], "HOLD")
+        self.assertAlmostEqual(result_lower["confidence"], 0.65)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for `get_sentiment_decision_from_score` in `src/sentiment_analysis.py` to fill a missing testing gap.

📊 **Coverage:** 
- BUY signals for scores > 0.15
- SELL signals for scores < -0.15
- HOLD signals for scores between -0.15 and 0.15
- Exact boundary checks (0.15 and -0.15 resolve to HOLD)
- Confidence capping behavior (confidence does not exceed 1.0)
- Analysis string formatting

✨ **Result:** 
Enhanced the test suite with robust coverage of sentiment analysis decisions, creating a safety net for future refactoring and capturing exact expected threshold logic.

---
*PR created automatically by Jules for task [2340290370188786324](https://jules.google.com/task/2340290370188786324) started by @laurentvv*