### PR TITLE
🧪 Add tests and improve error handling for get_timesfm_prediction

### DIFF
--- a/src/timesfm_model.py
+++ b/src/timesfm_model.py
@@ -106,4 +106,13 @@ class TimesFMModel:
             return {"signal": "HOLD", "confidence": 0.0, "analysis": f"Error: {e}"}
 
 def get_timesfm_prediction(df: pd.DataFrame) -> Dict:
-    return TimesFMModel.get_instance().predict(df)
+    """
+    Wrapper function to get predictions from the TimesFM model.
+    Handles singleton initialization automatically.
+    """
+    try:
+        model = TimesFMModel.get_instance()
+        return model.predict(df)
+    except Exception as e:
+        logger.error(f"TimesFM prediction failed: {e}")
+        return {"signal": "HOLD", "confidence": 0.0, "analysis": f"Model error: {e}"}

--- a/tests/test_timesfm_model.py
+++ b/tests/test_timesfm_model.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+
+from src.timesfm_model import get_timesfm_prediction
+
+class TestTimesFMModelWrapper(unittest.TestCase):
+    def setUp(self):
+        # Create a dummy DataFrame for testing
+        self.dummy_df = pd.DataFrame({'Close': [100, 105, 110]})
+
+    @patch('src.timesfm_model.TimesFMModel')
+    def test_get_timesfm_prediction_success(self, mock_timesfm_model_class):
+        # Setup mock behavior
+        mock_instance = MagicMock()
+        mock_prediction = {
+            "signal": "BUY",
+            "confidence": 0.8,
+            "analysis": "Mock analysis",
+            "predictions": [115.0]
+        }
+        mock_instance.predict.return_value = mock_prediction
+        mock_timesfm_model_class.get_instance.return_value = mock_instance
+
+        # Call function
+        result = get_timesfm_prediction(self.dummy_df)
+
+        # Assertions
+        mock_timesfm_model_class.get_instance.assert_called_once()
+        mock_instance.predict.assert_called_once_with(self.dummy_df)
+        self.assertEqual(result, mock_prediction)
+
+    @patch('src.timesfm_model.TimesFMModel')
+    def test_get_timesfm_prediction_exception(self, mock_timesfm_model_class):
+        # Setup mock behavior to raise exception
+        mock_timesfm_model_class.get_instance.side_effect = Exception("Mocked initialization error")
+
+        # Call function
+        result = get_timesfm_prediction(self.dummy_df)
+
+        # Assertions
+        self.assertEqual(result["signal"], "HOLD")
+        self.assertEqual(result["confidence"], 0.0)
+        self.assertTrue("Model error" in result["analysis"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap for `get_timesfm_prediction` function in `src/timesfm_model.py` which did not have appropriate tests. The function was also modified to include proper exception handling so any errors from TimesFM return a fallback dict instead of failing hard.
📊 **Coverage:** Successfully mocks `TimesFMModel.get_instance` and `model.predict`, adding explicit unit tests for both the happy path and the case where an exception is thrown.
✨ **Result:** Increased code reliability and robustness. Tests now verify proper wrapper behavior without triggering real inference or singleton instantiation.

---
*PR created automatically by Jules for task [16422080015196145568](https://jules.google.com/task/16422080015196145568) started by @laurentvv*