### PR TITLE
docs: generate python code health audit report

### DIFF
--- a/rapport_sante_code.md
+++ b/rapport_sante_code.md
@@ -1,0 +1,35 @@
+# 📊 Rapport de Santé du Code Python
+
+* **Résumé Exécutif :**
+  L'évaluation globale du dépôt est de grade **B+**.
+  La qualité générale est excellente (notée 9.99/10 par pylint, et la majorité des indices de maintenabilité sont notés 'A'). Il n'y a pas d'erreurs de style critiques ni d'imports inutilisés dans les sources de l'application (Ruff n'a rien détecté). De plus, aucun code mort n'a été trouvé par Vulture dans l'espace de travail. Cependant, il y a de la dette technique au niveau de la complexité algorithmique dans certains fichiers clés, et plusieurs blocs de code dupliqués qu'il serait intéressant de refactoriser.
+
+* **💀 Code Mort Confirmé et Suspecté :**
+  - **Ruff :** Aucun import ou variable inutilisés détectés.
+  - **Vulture :** Aucun code mort global détecté dans l'arborescence du projet (les exclusions des répertoires `vendor`, `tests` et de l'environnement virtuel limitent les faux positifs à 0).
+  - *Conclusion :* Aucun nettoyage de code mort n'est requis immédiatement.
+
+* **🔥 Hotspots de Complexité :**
+  Les 5 éléments nécessitant une refactorisation prioritaire (Complexité Cyclomatique de rang D à F selon Radon) :
+  1. `execute_t212_trade` dans `src/t212_executor.py` (Complexité : **F**)
+  2. `EnhancedDecisionEngine.make_enhanced_decision` dans `src/enhanced_decision_engine.py` (Complexité : **E**)
+  3. `VincentGanneModel.evaluate` dans `src/enhanced_decision_engine.py` (Complexité : **E**)
+  4. `get_alpha_vantage_data` dans `src/data.py` (Complexité : **E**)
+  5. `run_trading_analysis` dans `main.py` (Complexité : **D**)
+  *(Note : d'autres fonctions telles que `get_vincent_ganne_indicators` (D), `run_backtest` (D) ou `calculate_adaptive_weights` (D) méritent aussi l'attention).*
+
+* **👯 Clones et Duplications :**
+  Plusieurs blocs de code sont dupliqués (identifiés par Pylint) :
+  1. **Scripts Database Manager :** Grande duplication dans la gestion des données liée à l'extraction via Jina Reader API / AlphaEar (bloc similaire affiché dans les logs mais probablement entre un ancien backup/script non lié ou des copies temporaires).
+  2. **Initialisation des Poids de Décision :**
+     - Duplication entre `src/adaptive_weight_manager.py` (lignes 93-103) et `src/enhanced_decision_engine.py` (lignes 289-299) pour la configuration des `base_weights` (classic, llm_text, sentiment, timesfm, etc.).
+  3. **Initialisation du Logging système (encodage et format) :**
+     - Duplication entre `main.py` (lignes 31-41) et `schedule.py` (lignes 19-29).
+  4. **Initialisation de Base de Données / Logs de performance :**
+     - Duplication entre `src/adaptive_weight_manager.py` (lignes 149-159) et `src/performance_monitor.py` (lignes 125-135) pour la méthode `_init_database()`.
+
+* **🛠️ Plan d'Action Recommandé :**
+  1. **Refactoriser la Complexité de l'Executor T212 (Rang F) :** Diviser la fonction `execute_t212_trade` en sous-fonctions dédiées (ex: validation des fonds, construction de l'ordre, exécution API) afin d'améliorer la testabilité et la lisibilité.
+  2. **Centraliser les Configurations :** Créer un fichier de configuration commun (par ex. `src/config.py` ou via `.env`) pour stocker les `base_weights` et éviter la duplication entre l'Adaptive Weight Manager et le Decision Engine.
+  3. **Mutualiser l'Initialisation de la BDD :** Extraire les méthodes `_init_database()` dans une classe ou un module utilitaire commun de base de données, à réutiliser dans `adaptive_weight_manager.py` et `performance_monitor.py`.
+  4. **Simplifier le Moteur de Décision (Rang E) :** Découper `make_enhanced_decision` en délégant les différentes validations (sentiment, LLM, technique) à de plus petites méthodes privées pour abaisser sa complexité cyclomatique sous le seuil C.


### PR DESCRIPTION
Génère un rapport de santé du code Python (`rapport_sante_code.md`) suite à une analyse séquentielle en lecture seule utilisant `ruff`, `vulture`, `radon` et `pylint`. Identifie l'absence de code mort, et met en avant 5 hotspots de complexité et 4 blocs de duplication de code pour une refactorisation future. Le tout sans modifier le code source existant comme demandé.

---
*PR created automatically by Jules for task [3892991481172210885](https://jules.google.com/task/3892991481172210885) started by @laurentvv*