### PR TITLE
🔒 Fix SQL Injection vulnerability in database migrations

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -8,8 +8,6 @@ logger = logging.getLogger(__name__)
 
 DB_PATH = Path("trading_history.db")
 
-VALID_MODEL_TYPES = "'classic', 'llm_text', 'llm_visual', 'sentiment', 'hybrid', 'oil_bench', 'vincent_ganne', 'timesfm', 'tensortrade', 'grebenkov'"
-VALID_SIGNALS = "'BUY', 'SELL', 'HOLD', 'STRONG_BUY', 'STRONG_SELL'"
 
 
 def init_db():
@@ -49,13 +47,13 @@ def init_db():
     """)
 
     # Create model_signals table with updated constraints
-    cursor.execute(f"""
+    cursor.execute("""
         CREATE TABLE IF NOT EXISTS model_signals (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             date TEXT NOT NULL,
             ticker TEXT NOT NULL,
-            model_type TEXT NOT NULL CHECK(model_type IN ({VALID_MODEL_TYPES})),
-            signal TEXT NOT NULL CHECK(signal IN ({VALID_SIGNALS})),
+            model_type TEXT NOT NULL CHECK(model_type IN ('classic', 'llm_text', 'llm_visual', 'sentiment', 'hybrid', 'oil_bench', 'vincent_ganne', 'timesfm', 'tensortrade', 'grebenkov')),
+            signal TEXT NOT NULL CHECK(signal IN ('BUY', 'SELL', 'HOLD', 'STRONG_BUY', 'STRONG_SELL')),
             confidence REAL,
             details TEXT
         )
@@ -239,12 +237,12 @@ def _migrate_model_signals_table():
             cursor.execute("DROP TABLE IF EXISTS model_signals_old")
             cursor.execute("ALTER TABLE model_signals RENAME TO model_signals_old")
 
-            cursor.execute(f"""CREATE TABLE model_signals (
+            cursor.execute("""CREATE TABLE model_signals (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 date TEXT NOT NULL,
                 ticker TEXT NOT NULL,
-                model_type TEXT NOT NULL CHECK(model_type IN ({VALID_MODEL_TYPES})),
-                signal TEXT NOT NULL CHECK(signal IN ({VALID_SIGNALS})),
+                model_type TEXT NOT NULL CHECK(model_type IN ('classic', 'llm_text', 'llm_visual', 'sentiment', 'hybrid', 'oil_bench', 'vincent_ganne', 'timesfm', 'tensortrade', 'grebenkov')),
+                signal TEXT NOT NULL CHECK(signal IN ('BUY', 'SELL', 'HOLD', 'STRONG_BUY', 'STRONG_SELL')),
                 confidence REAL,
                 details TEXT
             )""")

--- a/uv.lock
+++ b/uv.lock
@@ -3731,7 +3731,7 @@ wheels = [
 
 [[package]]
 name = "timesfm"
-version = "2.0.0"
+version = "2.0.1"
 source = { directory = "vendor/timesfm" }
 dependencies = [
     { name = "huggingface-hub" },


### PR DESCRIPTION
🎯 **What:** The f-string vulnerability used during `CREATE TABLE` for `model_signals` (where python variables were dynamically injected into an SQL query) has been removed. The allowed items are now hardcoded natively into the SQLite query `CHECK IN` constraint for both `init_db` and `_migrate_model_signals_table`. The unused variables `VALID_MODEL_TYPES` and `VALID_SIGNALS` were also removed.
⚠️ **Risk:** While the immediate risk was minimal because the f-strings loaded hardcoded variables defined earlier in the file, retaining f-strings inside a DB operation is an anti-pattern. If refactoring eventually dynamically loaded the signals/model configs (e.g., from an environment or config file), this would open a massive SQL Injection vector.
🛡️ **Solution:** The query has been refactored into standard triple-quote python strings, perfectly mitigating injection by preventing evaluation of variables. Tests pass and formatting has been validated.

---
*PR created automatically by Jules for task [8351294236670694992](https://jules.google.com/task/8351294236670694992) started by @laurentvv*